### PR TITLE
Switch to popup in VSCode extension

### DIFF
--- a/ENGINEERING.md
+++ b/ENGINEERING.md
@@ -1,10 +1,10 @@
 # Engineering Plan
 
 ## Overview
-This project implements a minimal Visual Studio Code extension. When the extension activates, it automatically opens a Webview panel displaying the text **"Tinker"**.
+This project implements a minimal Visual Studio Code extension. When the extension activates, it automatically shows a modal popup displaying the text **"Tinker"**.
 
 ## Architecture
-- `src/extension.ts` – Contains the activation logic. It registers a command `tinker.showMessage`. Upon activation, the command is executed immediately, creating a Webview panel with simple HTML content.
+- `src/extension.ts` – Contains the activation logic. It registers a command `tinker.showMessage`. Upon activation, the command is executed immediately, displaying a modal information message.
 - `package.json` – Extension manifest defining activation events, commands, and build scripts.
 - `tsconfig.json` – TypeScript compiler configuration.
 - Compiled JavaScript is emitted to the `out` directory.
@@ -17,4 +17,4 @@ This project implements a minimal Visual Studio Code extension. When the extensi
 ## Design Notes
 - Activation uses the wildcard `*` so the extension loads on VSCode startup.
 - A command is registered so the panel can be displayed manually if desired, but activation automatically invokes it once.
-- The Webview content is static HTML to keep the extension lightweight and simple.
+- The extension uses VSCode's built-in modal message API to keep it lightweight and simple.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tinker VSCode Extension
 
-This repository contains a minimal VSCode extension that opens a screen with the text **"Tinker"** when the extension is activated.
+This repository contains a minimal VSCode extension that displays a popup window with the text **"Tinker"** when the extension is activated.
 
 ## Installation
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,33 +3,12 @@ import * as vscode from 'vscode';
 export function activate(context: vscode.ExtensionContext) {
     const command = 'tinker.showMessage';
     const disposable = vscode.commands.registerCommand(command, () => {
-        const panel = vscode.window.createWebviewPanel(
-            'tinkerWelcome',
-            'Tinker',
-            vscode.ViewColumn.One,
-            {}
-        );
-        panel.webview.html = getWebviewContent();
+        vscode.window.showInformationMessage('Tinker', { modal: true });
     });
     context.subscriptions.push(disposable);
 
-    // automatically show the screen on activation
+    // automatically show the popup on activation
     vscode.commands.executeCommand(command);
-}
-
-function getWebviewContent(): string {
-    return `<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none';">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tinker</title>
-</head>
-<body>
-    <h1>Tinker</h1>
-</body>
-</html>`;
 }
 
 export function deactivate() {}


### PR DESCRIPTION
## Summary
- remove webview creation and show a modal popup instead
- update docs to describe the new popup behavior

## Testing
- `npm install`
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_6867750306f08325a8dde6059f700c6d