### PR TITLE
Switch to chat-style interface

### DIFF
--- a/ENGINEERING.md
+++ b/ENGINEERING.md
@@ -1,10 +1,10 @@
 # Engineering Plan
 
 ## Overview
-This project implements a minimal Visual Studio Code extension. When the extension activates, it automatically shows a modal popup displaying the text **"Tinker"**.
+This project implements a minimal Visual Studio Code extension. When the extension activates, it opens a lightweight chat window where the user can send a command and view a response from a stubbed "Tinker" server.
 
 ## Architecture
-- `src/extension.ts` – Contains the activation logic. It registers a command `tinker.showMessage`. Upon activation, the command is executed immediately, displaying a modal information message.
+- `src/extension.ts` – Contains the activation logic. It registers a command `tinker.openChat`. Upon activation, it creates a Webview panel that hosts the chat interface.
 - `package.json` – Extension manifest defining activation events, commands, and build scripts.
 - `tsconfig.json` – TypeScript compiler configuration.
 - Compiled JavaScript is emitted to the `out` directory.
@@ -17,4 +17,4 @@ This project implements a minimal Visual Studio Code extension. When the extensi
 ## Design Notes
 - Activation uses the wildcard `*` so the extension loads on VSCode startup.
 - A command is registered so the panel can be displayed manually if desired, but activation automatically invokes it once.
-- The extension uses VSCode's built-in modal message API to keep it lightweight and simple.
+- The extension uses VSCode's Webview API to present the chat interface while keeping the implementation lightweight.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tinker VSCode Extension
 
-This repository contains a minimal VSCode extension that displays a popup window with the text **"Tinker"** when the extension is activated.
+This repository contains a minimal VSCode extension that opens a small chat window when the extension activates. Users can submit a command and see a response from a simple "Tinker" server function directly inside the chat screen.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinker-extension",
   "displayName": "Tinker",
-  "description": "A simple VSCode extension that shows a Tinker screen on activation.",
+  "description": "A simple VSCode extension that opens a chat-like Tinker screen on activation.",
   "version": "0.0.1",
   "engines": {
     "vscode": "^1.80.0"
@@ -12,7 +12,7 @@
   "contributes": {
     "commands": [
       {
-        "command": "tinker.showMessage",
+        "command": "tinker.openChat",
         "title": "Show Tinker Screen"
       }
     ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,14 +1,84 @@
 import * as vscode from 'vscode';
 
 export function activate(context: vscode.ExtensionContext) {
-    const command = 'tinker.showMessage';
+    const command = 'tinker.openChat';
     const disposable = vscode.commands.registerCommand(command, () => {
-        vscode.window.showInformationMessage('Tinker', { modal: true });
+        const panel = vscode.window.createWebviewPanel(
+            'tinkerChat',
+            'Tinker',
+            vscode.ViewColumn.Active,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true
+            }
+        );
+
+        panel.webview.html = getWebviewContent();
+
+        const tinkerServer = (text: string): string => {
+            return `Tinker server response: ${text}`;
+        };
+
+        panel.webview.onDidReceiveMessage(
+            message => {
+                if (message.command === 'send') {
+                    const response = tinkerServer(message.text);
+                    panel.webview.postMessage({ command: 'response', text: response });
+                }
+            },
+            undefined,
+            context.subscriptions
+        );
     });
     context.subscriptions.push(disposable);
 
-    // automatically show the popup on activation
     vscode.commands.executeCommand(command);
+}
+
+function getWebviewContent(): string {
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>
+body { font-family: sans-serif; margin: 0; padding: 10px; }
+#messages { margin-top: 10px; }
+.msg { margin: 5px 0; }
+</style>
+</head>
+<body>
+<input id="input" type="text" placeholder="Enter command" style="width:80%;" />
+<button id="send">Enter</button>
+<div id="messages"></div>
+<script>
+const vscode = acquireVsCodeApi();
+const input = document.getElementById('input');
+const messages = document.getElementById('messages');
+document.getElementById('send').addEventListener('click', send);
+input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+        send();
+    }
+});
+window.addEventListener('message', (event) => {
+    const msg = event.data;
+    if (msg.command === 'response') {
+        const div = document.createElement('div');
+        div.textContent = msg.text;
+        div.className = 'msg';
+        messages.appendChild(div);
+    }
+});
+function send() {
+    const text = input.value;
+    if (!text.trim()) { return; }
+    vscode.postMessage({ command: 'send', text });
+    input.value = '';
+}
+</script>
+</body>
+</html>`;
 }
 
 export function deactivate() {}


### PR DESCRIPTION
## Summary
- replace popup with a webview chat interface that opens on activation
- allow user text entry and display a stubbed response from a server
- update docs and package metadata for the new behaviour

## Testing
- `npm install`
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_686779dcf79c832583e1b9d4c83a6d5e